### PR TITLE
Improve --usernames parsing in check_admins.ps1

### DIFF
--- a/check_admins.ps1
+++ b/check_admins.ps1
@@ -3,7 +3,7 @@
 # Name:        check_admins.ps1
 # Date:        2020-02-07
 # Author:      nikola.vitanovic@atomia.com
-# Version:     1.1.0
+# Version:     1.1.1
 # Parameters:
 #              -domain 'Domain Admins'
 #              -local 'Administrators'
@@ -45,6 +45,11 @@ $currentDomain = ""
 $admins = ""
 $listOfUsernames = @()
 $listOfAdditionalUsernames = @()
+
+## Ensures that $usernames is array of usernames regardless of the parameter input method
+## Resolves: github.com/atomia/atomia-nagios-plugins/issues/7
+$usernames = $usernames.Split(',');
+
 # Get list of admins based on the type
 if($domain)
 {

--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,19 @@ Command: `$USER1$/check_nrpe -H $HOSTADDRESS$ -t 30 -c $ARG1$ -a $ARG2$`
 
 $ARG1$: `check_domain_admins`
 
-$ARG2$: `"ATOMIA\Administrator,ATOMIA\WindowsAdmin"`
+$ARG2$: `'"ATOMIA\Administrator","ATOMIA\WindowsAdmin"'`
+
+or
+
+$ARG2$: `'"ATOMIA\Administrator,ATOMIA\WindowsAdmin"'`
+
+> **Important:** Use double quotes `'"` - wrap whole argument in `'` quotes
+
+
+> **Important:** 
+> Use `check_nrpe_1arg` instead `check_nrpe` as _Check command_ in Nagios UI interface.
+>
+> `check_nrpe_1arg` passes `$ARG2$` argument via `-a` as required, where `check_nrpe` passes `$ARG2$` via `-c` and it is not properly substituted. Powershell script will get `$` as parameter value instead value in `$ARG2$`
 
 ## check_logons.ps1
 Nagios plugin that alerts if there are 4624 EventIDs aka logins in the Security event log of the system.


### PR DESCRIPTION
Due to misleading example in Readme.md:
```
$ARG2 = "ATOMIA\Administrator,ATOMIA\WindowsAdmin"
```
parameter `--usernames` is parsed as 
```
[
   "ATOMIA\Administrator,ATOMIA\WindowsAdmin"
]
``` 
instead
```
[
   "ATOMIA\Administrator",
   "ATOMIA\WindowsAdmin"
]
```
Correct way for specifying parameter is
```
 $ARG2 = "ATOMIA\Administrator","ATOMIA\WindowsAdmin"
```
as mentioned [here](https://github.com/atomia/atomia-nagios-plugins/issues/7#issuecomment-644993767)

These changes will ensure that `--usernames` parameter is correctly parsed even thought is wrongly specified as in Readme example.

Readme is updates with correct examples and additional setup info.